### PR TITLE
Added possibility to plot multiple scans (different values of couplin…

### DIFF
--- a/madanalysis_script.txt
+++ b/madanalysis_script.txt
@@ -1,5 +1,5 @@
 set main.recast = on
 set main.recast.store_root = True
 set main.recast.card_path = my_recast_card
-import ../../masterproject/tauDMproduction/no_mixing/Events/mvd5_mtad10/tag_11_pythia8_events.hepmc
-submit mvd5_mtad10
+import ../../masterproject/tauDMproduction/no_mixing/Events/mvd505_mtad760/tag_1_pythia8_events.hepmc
+submit mvd505_mtad760

--- a/madevent_script.txt
+++ b/madevent_script.txt
@@ -1,13 +1,13 @@
-launch mvd5_mtad10
+launch mvd505_mtad760
 shower=Pythia8
 detector = Delphes
 analysis=MadAnalysis5
 madspin=ON
 reweight=OFF
-set mtad 510
-set mvd 55
+set mtad 810
+set mvd 405
 set nevents 10000
-set gD 1
+set gD 0.01
 set mtap 800
 set decay 6000115 auto
 set decay 6000023 auto

--- a/main.py
+++ b/main.py
@@ -1,22 +1,16 @@
-from myplots import asimov_significance_color, asimov_significance_contour, exclusion_discovery_significance_contours
 from simulation import run_simulation
+from myplots import exclusion_discovery_significance_contours
 
 def main():
-    luminosity = 300 #fb^-1
-    #plot() decides what type of data is to be plotted
-    def plot(scan_paths, luminosity):
-        #asimov_significance_color(scan_paths, luminosity)
-        #asimov_significance_contour(scan_paths, luminosity)
-        exclusion_discovery_significance_contours(scan_paths, luminosity)
+    luminosity = [139] #fb^-1
 
     gD_001_path = '../../masterproject/tauDMproduction/no_mixing/Events/mvd5-305_mtad10-560_gD0.01'
     gD_1_path = '../../masterproject/tauDMproduction/no_mixing/Events/mvd5-455_mtad10-760_gD1'
 
-    #plot([gD_001_path], luminosity)
-    plot([gD_1_path], luminosity)
-    plot([gD_001_path, gD_1_path], luminosity)
+    exclusion_discovery_significance_contours([gD_001_path], luminosity, decreased_background_uncertainty = False,
+    relic_density_constraint = False, width_mass_ratio_lines = False)
 
-    #run_simulation([5, 5, 50], [10, 10, 50], 0.01, '../../masterproject/tauDMproduction/no_mixing') #mvd, mtad, gD, output_directory
+    #run_simulation([405, 505, 50], [760, 760, 50], 0.01, 800, '../../masterproject/tauDMproduction/no_mixing') #mvd, mtad, gD, output_directory
 
 if '__main__' == __name__:
     main()

--- a/miscellaneous.py
+++ b/miscellaneous.py
@@ -1,5 +1,5 @@
 import numpy as np
-import math
+import cmath
 
 #Help function that reads lists of data in string format and return lists of floats
 def read_save_file(file, line_index):
@@ -30,6 +30,5 @@ def inclusive_range(start, end, step):
 
 # Basic way of computing significance of signal compared to background
 def asimov_significance(S, B, sigma_b): #(signal and background in nr. of events)
-    return math.sqrt(2 * ((S + B) * math.log(((S+B)*(B + sigma_b**2))/(B**2 + (S + B)*sigma_b**2))
-    - (B**2/sigma_b**2) * math.log(1 + sigma_b**2 * S / (B*(B + sigma_b**2)))))
-    #return signal / (signal + background)**0.5
+    return cmath.sqrt(2 * ((S + B) * cmath.log(((S+B)*(B + sigma_b**2))/(B**2 + (S + B)*sigma_b**2))
+    - (B**2/sigma_b**2) * cmath.log(1 + ((sigma_b**2 * S) / (B*(B + sigma_b**2))))))

--- a/relic_density.py
+++ b/relic_density.py
@@ -50,7 +50,7 @@ def relic_density(scan_path, dark_coupling):
                 relic_density_matrix[i][j] = relic_density #Add relic density to correct place in relic density 2d array
     if relic_saved == False:
         data_file_path = './micromegas_5.2.13/masterproject_FG/work/models/vars1.mdl' #From madgraph/various directory
-        edit_line(data_file_path, 3, 'gD             |'+str(0.2)+'         |SU2D coupling constant      ')
+        edit_line(data_file_path, 3, 'gD             |'+str(dark_coupling)+'         |SU2D coupling constant      ')
         edit_line(data_file_path, 36, 'Mtap           |800          |Mass of tap.')
         edit_line(data_file_path, 38, 'Mh2            |300          |Mass of h2.')
 

--- a/significance_script.py
+++ b/significance_script.py
@@ -2,14 +2,18 @@ import numpy as np
 from Zstats import Zdisc, Zexcl
 from general_stuff import asimov_significance
 
-def significance_calculator(scan_path, luminosity, cross_sections, low_region_efficiencies, high_region_efficiencies, calculator):
-    SM_irreducible_background = 0.4312 + 0.02746 * 2 #2 neutrino final state processes (SM background)
-    low_region_background = 6.0 #nr of events
-    low_region_background_uncertainty = 1.7
-    high_region_background = 10.2
-    high_region_background_uncertainty = 3.3
+def significance_calculator(scan_path, luminosity, cross_sections, low_region_efficiencies, high_region_efficiencies, calculator = 'Zstats', decreased_background_uncertainty = False):
+    luminosity_scaling = luminosity / 139 #The background values are from a 139 fb^-1 search, assuming linear scaling of backgrounds and uncertainties
+    low_uncertainty_ratio = 1.7 / 6.0
+    high_uncertainty_ratio = 3.3 / 10.2
+    low_region_background = 6.0 * luminosity_scaling #nr of events
+    low_region_background_uncertainty = low_region_background * low_uncertainty_ratio
+    high_region_background = 10.2 * luminosity_scaling
+    high_region_background_uncertainty = high_region_background * high_uncertainty_ratio
+    if decreased_background_uncertainty:
+        high_region_background_uncertainty = high_region_background * 0.1
+        low_region_background_uncertainty = low_region_background * 0.1
 
-    asimov_array = np.zeros((len(cross_sections), len(cross_sections[0])), float)
     discovery_array = np.zeros((len(cross_sections), len(cross_sections[0])), float)
     exclusion_array = np.zeros((len(cross_sections), len(cross_sections[0])), float)
 
@@ -18,19 +22,27 @@ def significance_calculator(scan_path, luminosity, cross_sections, low_region_ef
             cross_section = 1000 * cross_sections[i][j] #Convert pb to fb
             low_region_signal = luminosity * cross_section * low_region_efficiencies[i][j] #luminosity in fb^-1, cross_section in fb (converted)
             high_region_signal = luminosity * cross_section * high_region_efficiencies[i][j]
-
+            if calculator == 'asimov':
+                z_low_region_sig = asimov_significance(low_region_signal, low_region_background, low_region_background_uncertainty).real
+                z_high_region_sig = asimov_significance(high_region_signal, high_region_background, high_region_background_uncertainty).real
+                if z_low_region_sig > z_high_region_sig:
+                    discovery_array[i][j] = z_low_region_sig
+                    exclusion_array[i][j] = z_low_region_sig
+                else:
+                    discovery_array[i][j] = z_high_region_sig
+                    exclusion_array[i][j] = z_high_region_sig
             if calculator == 'Zstats':
                 z_disc_low_region_signal = 0
                 z_disc_high_region_signal = 0
                 z_excl_low_region_signal = 0
                 z_excl_high_region_signal = 0
-                if (low_region_signal > 500) or (high_region_signal > 500): #Zstats can't handle too large number of events, compared to background
+                if (low_region_signal > 1000) or (high_region_signal > 1000): #Zstats can't handle too large number of events, compared to background
                     print('Too many signals for Zstats!')
-                    z_disc_low_region_signal = asimov_significance(low_region_signal, low_region_background, low_region_background_uncertainty)
-                    z_disc_high_region_signal = asimov_significance(high_region_signal, high_region_background, high_region_background_uncertainty)
+                    z_disc_low_region_signal = asimov_significance(low_region_signal, low_region_background, low_region_background_uncertainty).real
+                    z_disc_high_region_signal = asimov_significance(high_region_signal, high_region_background, high_region_background_uncertainty).real
 
-                    z_excl_low_region_signal = asimov_significance(low_region_signal, low_region_background, low_region_background_uncertainty)
-                    z_excl_high_region_signal = asimov_significance(high_region_signal, high_region_background, high_region_background_uncertainty)
+                    z_excl_low_region_signal = asimov_significance(low_region_signal, low_region_background, low_region_background_uncertainty).real
+                    z_excl_high_region_signal = asimov_significance(high_region_signal, high_region_background, high_region_background_uncertainty).real
                 else:
                     z_disc_low_region_signal = Zdisc(low_region_signal, low_region_background, low_region_background_uncertainty)
                     z_disc_high_region_signal = Zdisc(high_region_signal, high_region_background, high_region_background_uncertainty)
@@ -39,13 +51,17 @@ def significance_calculator(scan_path, luminosity, cross_sections, low_region_ef
                     z_excl_high_region_signal = Zexcl(high_region_signal, high_region_background, high_region_background_uncertainty)
 
                 if z_disc_low_region_signal > z_disc_high_region_signal:
+                    print(z_disc_low_region_signal)
                     discovery_array[i][j] = z_disc_low_region_signal
                 else:
                     discovery_array[i][j] = z_disc_high_region_signal
+                    print(z_disc_high_region_signal)
 
                 if z_excl_low_region_signal > z_excl_high_region_signal:
+                    print(z_excl_low_region_signal)
                     exclusion_array[i][j] = z_excl_low_region_signal
                 else:
                     exclusion_array[i][j] = z_excl_high_region_signal
+                    print(z_excl_high_region_signal)
 
-    return [asimov_array, discovery_array, exclusion_array]
+    return [exclusion_array, discovery_array]

--- a/simulation.py
+++ b/simulation.py
@@ -5,7 +5,7 @@ import shutil
 import gzip
 from general_stuff import inclusive_range, edit_line
 
-def run_simulation(mvd_properties, mtad_properties, dark_coupling, output_directory):
+def run_simulation(mvd_properties, mtad_properties, dark_coupling, mtap, output_directory):
     mtad_min = mtad_properties[0] #Retrieve mass data for odd dark tau and DM candidate
     mtad_max = mtad_properties[1]
     mtad_step = mtad_properties[2]
@@ -19,6 +19,7 @@ def run_simulation(mvd_properties, mtad_properties, dark_coupling, output_direct
     event_directory = output_directory + '/Events'
 
     edit_line(madevent_script_file, 9, 'set gD ' + str(dark_coupling)) #Set the value for the dark coupling from the input parameter
+    edit_line(madevent_script_file, 10, 'set mtap ' + str(mtap))
     scan_name = 'mvd' + str(mvd_min) + '-' + str(mvd_max) + '_mtad' + str(mtad_min) + '-' + str(mtad_max) + '_gD' + str(dark_coupling)
     scan_directory = event_directory + '/' + scan_name
     if not exists(scan_directory):
@@ -26,7 +27,7 @@ def run_simulation(mvd_properties, mtad_properties, dark_coupling, output_direct
 
     #Setup the save file which will contain cross sections, the scan region, low- and high signal region detector effiencies, relic_densities
     save_file = open(scan_directory + '/saved_scan_data', 'w')
-    save_file_setup = ['[]\n', str(mvd_properties) + '\n', str(mtad_properties) + '\n', '[]\n', '[]\n', '[]\n', '[]\n', '[]\n']
+    save_file_setup = ['[]\n', str(mvd_properties) + '\n', str(mtad_properties) + '\n', '[]\n', '[]\n', '[]\n', '[]\n', str(dark_coupling) + '\n', str(mtap) + '\n']
     save_file_setup = ''.join(save_file_setup)
     save_file.write(save_file_setup)
     save_file.close()


### PR DESCRIPTION
…g) and different values of the luminosity at the same time. Removed old unused code/comments/prints. The width/mass ratio for the tau odd particle is now computed from the analytical formula instead of with the width value computed by MadGraph. The plot function now takes arguments that controls whether relic density constraints, constant width/mass lines should be drawn. The background uncertainty can also be toggled between improved value (10%), or current value of around 30%. The relic density constraints are now drawn for the lowest coupling if multiple scans are considered, while the width/mass lines are drawn for the highest coupling.